### PR TITLE
Visual changes for accessibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "globle",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "globle",
-      "version": "0.1.0",
+      "version": "1.1.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/react": "^12.1.2",

--- a/src/components/Globe.tsx
+++ b/src/components/Globe.tsx
@@ -16,6 +16,7 @@ type Props = {
 export default function Globe({ guesses, globeRef }: Props) {
   // Theme
   const { nightMode } = useContext(ThemeContext).theme;
+  const { highContrast } = useContext(ThemeContext).theme;
 
   // Check device
   const isMobile = useCheckMobile();
@@ -70,7 +71,7 @@ export default function Globe({ guesses, globeRef }: Props) {
         backgroundColor="#00000000"
         polygonsData={guesses}
         // @ts-ignore
-        polygonCapColor={(c) => getColour(c, answerCountry, nightMode)}
+        polygonCapColor={(c) => getColour(c, answerCountry, nightMode, highContrast)}
         // @ts-ignore
         polygonLabel={({ properties: d }) => `
         <b class="text-black dark:text-gray-300">${d.ADMIN}</b> 

--- a/src/components/Outline.tsx
+++ b/src/components/Outline.tsx
@@ -13,6 +13,7 @@ type Props = {
 
 export default function Outline({ countryName, width }: Props) {
   const { nightMode } = useContext(ThemeContext).theme;
+  const { highContrast } = useContext(ThemeContext).theme;
 
   const country = countryData.find((p) => p.properties.NAME === countryName);
   if (!country)
@@ -30,7 +31,7 @@ export default function Outline({ countryName, width }: Props) {
 
   const outline = getPath(countryName);
 
-  const colour = getColour(countryCopy, sampleAnswer, nightMode);
+  const colour = getColour(countryCopy, sampleAnswer, nightMode, highContrast);
 
   return (
     <figure className="flex w-4/5 space-x-6 md:flex-col md:justify-left md:space-x-0">

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -22,15 +22,16 @@ function Toggle({ checked }: { checked: boolean }) {
 export default function Settings() {
   const themeContext = useContext(ThemeContext);
   const [toggleTheme, setToggleTheme] = useState(!themeContext.theme.nightMode);
+  const [toggleHighContrast, setToggleHighContrast] = useState(!themeContext.theme.highContrast);
   const [toggleScope, setToggleScope] = useState(true);
 
   const { setTheme } = themeContext;
 
   useEffect(() => {
     if (setTheme) {
-      setTheme({ nightMode: !toggleTheme });
+      setTheme({ nightMode: !toggleTheme, highContrast: !toggleHighContrast });
     }
-  }, [toggleTheme, setTheme]);
+  }, [toggleTheme, toggleHighContrast, setTheme]);
 
   function keyPressToggle(
     e: React.KeyboardEvent<HTMLLabelElement>,
@@ -50,6 +51,13 @@ export default function Settings() {
       toggle: toggleTheme,
       on: "Day Theme",
       off: "Night Theme",
+    },
+    {
+      name: "accessibility",
+      setToggle: setToggleHighContrast,
+      toggle: toggleHighContrast,
+      on: "Default Contrast",
+      off: "High Contrast",
     },
     {
       name: "scope",

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -10,6 +10,7 @@ type ProviderProps = {
 
 type Theme = {
   nightMode: boolean;
+  highContrast: boolean;
 };
 
 type ThemeContextType = {
@@ -17,7 +18,7 @@ type ThemeContextType = {
   setTheme: React.Dispatch<React.SetStateAction<Theme>> | null;
 };
 
-const initialTheme: Theme = { nightMode: false };
+const initialTheme: Theme = { nightMode: false, highContrast: false };
 
 const initialThemeContext: ThemeContextType = {
   theme: initialTheme,

--- a/src/util/colour.ts
+++ b/src/util/colour.ts
@@ -1,18 +1,19 @@
 import { scaleSequentialSqrt } from "d3-scale";
-import { interpolateBuPu, interpolateOrRd } from "d3-scale-chromatic";
+import { interpolateBuPu, interpolateOrRd, interpolateGreys } from "d3-scale-chromatic";
 import { Country } from "../lib/country";
 import { polygonDistance } from "./distance";
 
 export const getColour = (
   guess: Country,
   answer: Country,
-  nightMode: boolean
+  nightMode: boolean,
+  highContrast: boolean
 ) => {
   if (guess.properties.NAME === answer.properties.NAME) return "green";
   if (guess.proximity == null) {
     guess["proximity"] = polygonDistance(guess, answer);
   }
-  const gradient = nightMode ? interpolateBuPu : interpolateOrRd;
+  const gradient = highContrast ? interpolateGreys : (nightMode ? interpolateBuPu : interpolateOrRd);
   const colorScale = scaleSequentialSqrt(gradient).domain([15_000_000, 0]);
   const colour = colorScale(guess.proximity);
   return colour;


### PR DESCRIPTION
Why:
Currently there doesn't exist a way to have a coloring option that is more friendly to colorblind users. 

What:
This change adds an option to enable a "High contrast" mode. Which changes the gradient from white to black. Which is not a perfect solution but the changes from white to black are a bit easier to discern over the current colors.
