### PR TITLE
Removing Browser Autofill

### DIFF
--- a/src/components/Guesser.tsx
+++ b/src/components/Guesser.tsx
@@ -91,6 +91,7 @@ export default function Guesser({ guesses, setGuesses, win, setWin }: Props) {
           onChange={(e) => setGuessName(e.currentTarget.value)}
           disabled={win}
           placeholder={guesses.length === 0 ? "Enter country name here" : ""}
+          autoComplete="new-password"
         />
         <button
           className="bg-blue-700 dark:bg-purple-800 hover:bg-blue-900 dark:hover:bg-purple-900 disabled:bg-blue-900  text-white 


### PR DESCRIPTION
Why: When playing on mobile or computer the browser will try to autofill the guess box with either previous input or something it deems proper. This can be annoying and distracting for user.

What: Added property to guesser to remove the autofill suggestion. StackOverflow states the "new-password" value works better than "off" which I found to be true as well.