### PR TITLE
Add suggestions for spelling mistakes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "globle",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "globle",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/react": "^12.1.2",
@@ -17,6 +17,7 @@
         "@types/react-dom": "^17.0.11",
         "d3-scale": "^4.0.2",
         "d3-scale-chromatic": "^3.0.0",
+        "edit-distance": "^1.0.5",
         "eslint-config-react-app": "^7.0.0",
         "react": "^17.0.2",
         "react-device-detect": "^2.1.2",
@@ -6258,6 +6259,11 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
       "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug=="
+    },
+    "node_modules/edit-distance": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/edit-distance/-/edit-distance-1.0.5.tgz",
+      "integrity": "sha512-kgJKxFAxa6PlpfVAiCfj8uCUyhs6PZWZDxW2EaX7ra1+WmLkoVjG9Z1BHfPDfhrJvWaOSm9qf/CmxqH44EVlcQ=="
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -19592,6 +19598,11 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
       "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug=="
+    },
+    "edit-distance": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/edit-distance/-/edit-distance-1.0.5.tgz",
+      "integrity": "sha512-kgJKxFAxa6PlpfVAiCfj8uCUyhs6PZWZDxW2EaX7ra1+WmLkoVjG9Z1BHfPDfhrJvWaOSm9qf/CmxqH44EVlcQ=="
     },
     "ee-first": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react-scripts": "5.0.0",
     "spherical-geometry-js": "^3.0.0",
     "typescript": "^4.5.4",
-    "web-vitals": "^2.1.3"
+    "web-vitals": "^2.1.3",
+    "edit-distance": "^1.0.5"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/Guesser.tsx
+++ b/src/components/Guesser.tsx
@@ -52,6 +52,55 @@ export default function Guesser({
     });
   }
 
+  function getCloseMatches(countryName: string, list: Country[], threshold: number): string[] {
+
+    const targets: string[] = alternateNames.map(pair => pair.alternative);
+
+    if (locale === "en-CA") {
+      list.forEach((country) => {
+        const { NAME, NAME_LONG, /*ABBREV,*/ ADMIN, BRK_NAME, NAME_SORT } =
+          country.properties;
+        targets.push(...[NAME, NAME_LONG,/* ABBREV,*/ ADMIN, BRK_NAME, NAME_SORT]);
+      });
+    } else {
+      list.forEach((country) => {
+        targets.push(country.properties[langName]);
+      });
+    }
+
+    const insertCost = (char: string) => 1;
+    const removeCost = (char: string) => 1;
+    const updateCost = (charA: string, charB: string) => {
+      //Accent error count as 0.5. Different letter count as 1.
+      return charA !== charB ? (removeAccent(charA) !== removeAccent(charB) ? 1 : 0.5) : 0;
+    };
+
+    const removeAccent = (char: string) => {
+      return char.normalize('NFD').replace(/[\u0300-\u036f]/g, "");
+    };
+
+    const computeDistance = (hypothesis: string, reference: string) => {
+      var result = levenshtein(hypothesis.toLowerCase(), reference.toLowerCase(), insertCost, removeCost, updateCost);
+      return result.distance;
+    }
+
+    const matches: { target: string, distance: number }[] = [];
+    targets.forEach(target => {
+      const distance = computeDistance(countryName, target);
+      if (distance <= threshold) {
+        matches.push({ distance, target })
+      }
+    });
+
+    matches.sort((a, b) => a.distance - b.distance);
+    var closeMatches = matches.map(element => element.target);
+
+    //remove duplicates
+    return closeMatches.reduce((a: string[], b: string) => {
+      if (a.indexOf(b) < 0) a.push(b);
+      return a;
+    }, []);
+  }
   // Check territories function
   function runChecks() {
     const trimmedName = guessName
@@ -70,7 +119,13 @@ export default function Guesser({
     }
     const guessCountry = findCountry(userGuess, countryData);
     if (!guessCountry) {
-      setError(localeList[locale]["Game5"]);
+      const closeMatches = getCloseMatches(userGuess, countryData, 2);
+      if (closeMatches.length > 0) {
+        setError(localeList[locale]["Game9"].replaceAll(/\{country\}/g, closeMatches.join(", ")));
+      }
+      else {
+        setError(localeList[locale]["Game5"]);
+      }
       return;
     }
     if (practiceMode) {

--- a/src/components/Guesser.tsx
+++ b/src/components/Guesser.tsx
@@ -8,6 +8,8 @@ import { LocaleContext } from "../i18n/LocaleContext";
 import localeList from "../i18n/messages";
 import { FormattedMessage } from "react-intl";
 import { langNameMap } from "../i18n/locales";
+import { levenshtein } from "edit-distance";
+
 const countryData: Country[] = require("../data/country_data.json").features;
 
 type Props = {

--- a/src/i18n/messages/de-DE.ts
+++ b/src/i18n/messages/de-DE.ts
@@ -45,6 +45,7 @@ export const German: Messages = {
   Game6: "Das Land wurde schon versucht",
   Game7: "Das geheime Land ist {answer}!",
   Game8: "Nächste Grenze",
+  Game9: `Ungültiger Versuch. {country}?`, //TODO: translate
   StatsTitle: "Statistiken",
   Stats1: "Letzter Sieg",
   Stats2: "Heutige Versuche",

--- a/src/i18n/messages/en-CA.ts
+++ b/src/i18n/messages/en-CA.ts
@@ -45,6 +45,7 @@ export const English: Messages = {
   Game6: "Country already guessed",
   Game7: "The Mystery Country is {answer}!",
   Game8: "Closest border",
+  Game9: `Invalid guess. Did you mean {country}?`,
   StatsTitle: "Statistics",
   Stats1: "Last win",
   Stats2: "Today's guesses",

--- a/src/i18n/messages/es-MX.ts
+++ b/src/i18n/messages/es-MX.ts
@@ -42,6 +42,7 @@ export const Spanish: Messages = {
   Game6: "Pais ya adivinado",
   Game7: "¡El País Secreto es {answer}!",
   Game8: "Frontera más cercana",
+  Game9: `Intento inválido. {country}?`, //TODO: translate
   StatsTitle: "Estadísticas",
   Stats1: "Última victoria	",
   Stats2: "Intentos de hoy",

--- a/src/i18n/messages/fr-FR.ts
+++ b/src/i18n/messages/fr-FR.ts
@@ -46,6 +46,7 @@ export const French: Messages = {
   Game6: "Pays déjà tenté",
   Game7: "Le pays mystère est {answer}!",
   Game8: "Frontière la plus proche",
+  Game9: `Tentative invalide. Voulez-vous dire {country}?`,
   StatsTitle: "Statistiques",
   Stats1: "Dernière victoire",
   Stats2: "Tentatives d'aujourd'hui",

--- a/src/i18n/messages/pt-BR.ts
+++ b/src/i18n/messages/pt-BR.ts
@@ -45,6 +45,7 @@ export const Portuguese: Messages = {
   Game6: "Você já chutou este país",
   Game7: "O país misterioso é {answer}!",
   Game8: "Fronteira mais próxima",
+  Game9: `Tentativa inválida. {country}?`, //TODO: translate
   StatsTitle: "Estatísticas",
   Stats1: "Última vitória",
   Stats2: "Palpites de hoje",

--- a/src/lib/edit-distance.d.ts
+++ b/src/lib/edit-distance.d.ts
@@ -1,0 +1,19 @@
+declare module "edit-distance" {
+  //Just adding the minimum type declarations for what we use of edit-distance.
+  export interface distanceInfo {
+    a: string;
+    b: string;
+    distance: number;
+  }
+
+  export type simpleCostFunction = (char: string) => number;
+  export type compareCostFunction = (charA: string, charB: string) => number;
+
+  export function levenshtein(
+    stringA: string,
+    stringB: string,
+    insertCb: simpleCostFunction,
+    removeCb: simpleCostFunction,
+    updateCb: compareCostFunction
+  ): distanceInfo;
+}

--- a/src/lib/locale.d.ts
+++ b/src/lib/locale.d.ts
@@ -41,6 +41,7 @@ export type Messages = {
   Game6: string;
   Game7: string;
   Game8: string;
+  Game9: string;
   StatsTitle: string;
   Stats1: string;
   Stats2: string;


### PR DESCRIPTION
Whenever there is one or two spelling errors (accent error count as 1/2 error), Globle will suggest the right country name in the error message, forcing the player to type the name correctly (and learn the proper spelling of the country).

If language is en-CA, the suggestions will look into all available form except abbreviations, which would trigger too often.

![image](https://user-images.githubusercontent.com/813371/170824263-a5c4cb8a-9b98-40c8-a178-93f23221ba3c.png)

If there is more than one candiate, they are all displayed:
![image](https://user-images.githubusercontent.com/813371/170824332-c45cdf3b-31c9-44c6-a7fe-0ad90f66676a.png)

If the edit distance is greater than 2, the normal error message is displayed:
![image](https://user-images.githubusercontent.com/813371/170824627-6894aaa7-8ce0-4096-af52-2561c0536c24.png)

For other languages, the suggestions will be limited to country names in this language, even if English names are accepted by the game.

![image](https://user-images.githubusercontent.com/813371/170824362-ceadacc8-9988-4fca-9e76-d1a283f7f07a.png)

In languages other than French and English, there is no "Did you mean" prefix before the suggestion. Translators can provide the right wording.
![image](https://user-images.githubusercontent.com/813371/170824500-bc7f2f03-6c89-4f84-b3f0-0f0ac7212a85.png)

