### PR TITLE
Fix turning to wrong country when sorted by guess order

### DIFF
--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -62,7 +62,7 @@ export default function List({ guesses, win, globeRef }: Props) {
   const qualifier = win ? "Answer" : "Closest";
 
   function turnToCountry(e: SyntheticEvent, idx: number) {
-    const clickedCountry = orderedGuesses[idx];
+    const clickedCountry = isSortedByDistance ? orderedGuesses[idx] : guesses[idx];
     const { lat, lng, altitude } = findCentre(clickedCountry);
     turnGlobe({ lat, lng, altitude }, globeRef, "zoom");
   }


### PR DESCRIPTION
This commit fixes this issue: When the list of guesses is sorted by guessing order, clicking on one of the guesses turns to the country that would have been in that position if the list were ordered by distance.