### PR TITLE
fix(guesser): remove extra spaces between words in guessed name

### DIFF
--- a/src/components/Guesser.tsx
+++ b/src/components/Guesser.tsx
@@ -53,7 +53,7 @@ export default function Guesser({
   // Check territories function
   function runChecks() {
     const trimmedName = guessName
-      .trim()
+      .replace(/\s+/g,' ').trim()
       .toLowerCase()
       .replace(/&/g, "and")
       .replace(/^st\s/g, "st. ");


### PR DESCRIPTION
This replaces extra spaces in guessed name with only one space to aid matching.

The reason I chose to put this together in the same line with .trim() was because they both remove extra spaces, unlike the last lines that do domain-specific replacements.

Fixes: #122