### PR TITLE
feat(guesser): select input text when guess is rejected

### DIFF
--- a/src/components/Guesser.tsx
+++ b/src/components/Guesser.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useContext, useState } from "react";
+import { FormEvent, useContext, useState, useRef, useEffect } from "react";
 import { Country } from "../lib/country";
 import { answerCountry, answerName } from "../util/answer";
 import { Message } from "./Message";
@@ -30,6 +30,11 @@ export default function Guesser({
   const { locale } = useContext(LocaleContext);
 
   const langName = langNameMap[locale];
+
+  const ref = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    ref.current?.focus();
+  }, [ref]);
 
   function findCountry(countryName: string, list: Country[]) {
     return list.find((country) => {
@@ -65,11 +70,13 @@ export default function Guesser({
     const alreadyGuessed = findCountry(userGuess, guesses);
     if (alreadyGuessed) {
       setError(localeList[locale]["Game6"]);
+      ref.current?.select();
       return;
     }
     const guessCountry = findCountry(userGuess, countryData);
     if (!guessCountry) {
       setError(localeList[locale]["Game5"]);
+      ref.current?.select();
       return;
     }
     if (practiceMode) {
@@ -128,6 +135,7 @@ export default function Guesser({
           id="guesser"
           value={guessName}
           onChange={(e) => setGuessName(e.currentTarget.value)}
+          ref={ref}
           disabled={win}
           placeholder={guesses.length === 0 ? localeList[locale]["Game1"] : ""}
           autoComplete="new-password"


### PR DESCRIPTION
This selects the current input text when it is rejected as invalid or already guessed. Then the next input text replaces, not appends to current text. Previously, one needed to manually select the text, and now you can just type over it. This also puts the focus into the input field on navigation instead of needing you to click on it before typing, but if you come to the game page directly by URL/link, the focus going to the field doesn't work yet.