### PR TITLE
GL-142 - add direction hint

### DIFF
--- a/src/components/Guesser.tsx
+++ b/src/components/Guesser.tsx
@@ -9,6 +9,7 @@ import localeList from "../i18n/messages";
 import { FormattedMessage } from "react-intl";
 import { langNameMap } from "../i18n/locales";
 import { AltNames } from "../lib/alternateNames";
+import {polygonDirection} from "../util/direction";
 const countryData: Country[] = require("../data/country_data.json").features;
 const alternateNames: AltNames = require("../data/alternate_names.json");
 
@@ -99,22 +100,21 @@ export default function Guesser({
     e.preventDefault();
     setError("");
     let guessCountry = runChecks();
+    let guessAnswerCountry = answerCountry;
     if (practiceMode) {
-      const answerCountry = JSON.parse(
+      guessAnswerCountry = JSON.parse(
         localStorage.getItem("practice") as string
       );
-      if (guessCountry && answerCountry) {
-        guessCountry["proximity"] = polygonDistance(
-          guessCountry,
-          answerCountry
-        );
-        setGuesses([...guesses, guessCountry]);
-        setGuessName("");
-        return;
-      }
     }
-    if (guessCountry && answerCountry) {
-      guessCountry["proximity"] = polygonDistance(guessCountry, answerCountry);
+    if (guessCountry && guessAnswerCountry) {
+      guessCountry.proximity = polygonDistance(
+          guessCountry,
+          guessAnswerCountry
+      );
+      guessCountry.direction = polygonDirection(
+          guessCountry,
+          guessAnswerCountry
+      );
       setGuesses([...guesses, guessCountry]);
       setGuessName("");
     }

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -152,6 +152,12 @@ export default function List({ guesses, win, globeRef, practiceMode }: Props) {
               off="miles"
             />
           </div>
+          <div className="flex items-center space-x-1">
+            <p>
+              <FormattedMessage id="Game9" />:{" "}
+              {closest?.direction}
+            </p>
+          </div>
           <p>
             <button
               onClick={() => setIsSortedByDistance(!isSortedByDistance)}

--- a/src/components/Outline.tsx
+++ b/src/components/Outline.tsx
@@ -5,6 +5,7 @@ import { useContext } from "react";
 import { ThemeContext } from "../context/ThemeContext";
 import { getPath } from "../util/svg";
 import { FormattedMessage } from "react-intl";
+import {polygonDirection} from "../util/direction";
 const countryData: Country[] = require("../data/country_data.json").features;
 
 type Props = {
@@ -27,7 +28,14 @@ export default function Outline({ countryName, width }: Props) {
   if (!sampleAnswer)
     throw new Error("Country in Help screen not found in Country Data");
 
-  countryCopy["proximity"] = polygonDistance(countryCopy, sampleAnswer);
+  countryCopy.proximity = polygonDistance(
+      countryCopy,
+      sampleAnswer
+  );
+  countryCopy.direction = polygonDirection(
+      countryCopy,
+      sampleAnswer
+  );
 
   const outline = getPath(countryName);
 

--- a/src/i18n/messages/de-DE.ts
+++ b/src/i18n/messages/de-DE.ts
@@ -45,6 +45,7 @@ export const German: Messages = {
   Game6: "Das Land wurde schon versucht",
   Game7: "Das geheime Land ist {answer}!",
   Game8: "Nächste Grenze",
+  Game9: "Richtung",
   StatsTitle: "Statistiken",
   Stats1: "Letzter Sieg",
   Stats2: "Heutige Versuche",

--- a/src/i18n/messages/en-CA.ts
+++ b/src/i18n/messages/en-CA.ts
@@ -47,6 +47,7 @@ export const English: Messages = {
   Game6: "Country already guessed",
   Game7: "The Mystery Country is {answer}!",
   Game8: "Closest border",
+  Game9: "Direction",
   StatsTitle: "Statistics",
   Stats1: "Last win",
   Stats2: "Today's guesses",

--- a/src/i18n/messages/es-MX.ts
+++ b/src/i18n/messages/es-MX.ts
@@ -42,6 +42,7 @@ export const Spanish: Messages = {
   Game6: "Pais ya adivinado",
   Game7: "¡El País Secreto es {answer}!",
   Game8: "Frontera más cercana",
+  Game9: "Dirección",
   StatsTitle: "Estadísticas",
   Stats1: "Última victoria	",
   Stats2: "Intentos de hoy",

--- a/src/i18n/messages/fr-FR.ts
+++ b/src/i18n/messages/fr-FR.ts
@@ -46,6 +46,7 @@ export const French: Messages = {
   Game6: "Pays déjà tenté",
   Game7: "Le pays mystère est: {answer}!",
   Game8: "Frontière la plus proche",
+  Game9: "Direction",
   StatsTitle: "Statistiques",
   Stats1: "Dernière victoire",
   Stats2: "Tentatives d'aujourd'hui",

--- a/src/i18n/messages/hu-HU.ts
+++ b/src/i18n/messages/hu-HU.ts
@@ -45,6 +45,7 @@ export const Hungarian: Messages = {
   Game6: "Ezt az országot már próbáltad",
   Game7: "A keresett ország {answer}!",
   Game8: "Legközelebbi határ:",
+  Game9: "Irány:",
   StatsTitle: "Statisztika",
   Stats1: "Utolsó nyerés",
   Stats2: "Mai próbálkozások",

--- a/src/i18n/messages/it_IT.ts
+++ b/src/i18n/messages/it_IT.ts
@@ -46,6 +46,7 @@ export const Italian: Messages = {
   Game6: "Paese già provato",
   Game7: "Il paese misterioso è {answer}!",
   Game8: "Confine più vicino",
+  Game9: "Direzione",
   StatsTitle: "Statistiche",
   Stats1: "Ultima vittoria",
   Stats2: "Tentativi di oggi",

--- a/src/i18n/messages/pl-PL.ts
+++ b/src/i18n/messages/pl-PL.ts
@@ -41,6 +41,7 @@ export const Polish: Messages = {
   Game6: "Ten kraj już się pojawił",
   Game7: "Tajemniczy Kraj to {answer}!",
   Game8: "Najbliższa granica",
+  Game9: "Kierunek",
   StatsTitle: "Statystyki",
   Stats1: "Ostatnie zwycięstwo",
   Stats2: "Dzisiejsze próby",

--- a/src/i18n/messages/pt-BR.ts
+++ b/src/i18n/messages/pt-BR.ts
@@ -45,6 +45,7 @@ export const Portuguese: Messages = {
   Game6: "Você já chutou este país",
   Game7: "O país misterioso é {answer}!",
   Game8: "Fronteira mais próxima",
+  Game9: "Direção",
   StatsTitle: "Estatísticas",
   Stats1: "Última vitória",
   Stats2: "Palpites de hoje",

--- a/src/i18n/messages/sv-SE.ts
+++ b/src/i18n/messages/sv-SE.ts
@@ -41,6 +41,7 @@ export const Swedish: Messages = {
   Game6: "Landet redan gissat",
   Game7: "Mysterielandet är {answer}!",
   Game8: "Närmsta gräns",
+  Game9: "Riktning",
   StatsTitle: "Statistik",
   Stats1: "Senaste vinst",
   Stats2: "Dagens gissningar",

--- a/src/lib/country.d.ts
+++ b/src/lib/country.d.ts
@@ -1,6 +1,7 @@
 export type Country = {
   type: string;
   proximity: number;
+  direction: string;
   properties: {
     scalerank: number;
     featurecla: string;

--- a/src/lib/locale.d.ts
+++ b/src/lib/locale.d.ts
@@ -52,6 +52,7 @@ export type Messages = {
   Game6: string;
   Game7: string;
   Game8: string;
+  Game9: string;
   StatsTitle: string;
   Stats1: string;
   Stats2: string;

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -9,6 +9,7 @@ import { polygonDistance } from "../util/distance";
 import { getColourEmoji } from "../util/colour";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { FormattedMessage } from "react-intl";
+import {polygonDirection} from "../util/direction";
 
 const Globe = lazy(() => import("../components/Globe"));
 const Guesser = lazy(() => import("../components/Guesser"));
@@ -62,9 +63,13 @@ export default function Game({ reSpin, setShowStats }: Props) {
           return country.properties.NAME === guess;
         });
         if (!foundCountry) throw new Error("Country mapping broken");
-        foundCountry["proximity"] = polygonDistance(
+        foundCountry.proximity = polygonDistance(
           foundCountry,
           answerCountry
+        );
+        foundCountry.direction = polygonDirection(
+            foundCountry,
+            answerCountry
         );
         return foundCountry;
       });

--- a/src/util/colour.ts
+++ b/src/util/colour.ts
@@ -7,6 +7,7 @@ import {
 } from "d3-scale-chromatic";
 import { Country } from "../lib/country";
 import { polygonDistance } from "./distance";
+import {polygonDirection} from "./direction";
 
 const GREEN_SQUARE = "🟩";
 const ORANGE_SQUARE = "🟧";
@@ -29,7 +30,10 @@ export const getColour = (
   }
   if (guess.properties.NAME === answer.properties.NAME) return "green";
   if (guess.proximity == null) {
-    guess["proximity"] = polygonDistance(guess, answer);
+    guess.proximity = polygonDistance(guess, answer);
+  }
+  if (guess.direction == null) {
+    guess.direction = polygonDirection(guess, answer);
   }
   const gradient = highContrast
     ? interpolateGreys
@@ -46,7 +50,10 @@ export const getColour = (
 export const getColourEmoji = (guess: Country, answer: Country) => {
   if (guess.properties.NAME === answer.properties.NAME) return GREEN_SQUARE;
   if (guess.proximity == null) {
-    guess["proximity"] = polygonDistance(guess, answer);
+    guess.proximity = polygonDistance(guess, answer);
+  }
+  if (guess.direction == null) {
+    guess.direction = polygonDirection(guess, answer);
   }
   const scale = guess.proximity / MAX_DISTANCE;
   if (scale < 0.1) {

--- a/src/util/direction.ts
+++ b/src/util/direction.ts
@@ -1,0 +1,62 @@
+import * as geometry from "spherical-geometry-js";
+import { Country } from "../lib/country";
+import {polygonPoints} from "./geometry"
+
+function average(values: number[]) {
+    if (values.length === 0) {
+        return null;
+    }
+
+    let sum = 0;
+    for (let i = 0; i < values.length; i++) {
+        sum += values[i];
+    }
+    return sum / values.length;
+}
+
+// very silly implementation of centroid that's good enough for our purposes
+// suggestion: two libraries that do distance, bearing and centroid:
+// https://turfjs.org
+// https://www.npmjs.com/package/geodesy
+function polygonNaiveCentroid(points: number[][]) {
+    const lat = average(points.map(point => point[0]));
+    const lng = average(points.map(point => point[1]));
+    return [lat, lng] as [number, number];
+}
+
+function calcDirection(centroid1: [number, number], centroid2: [number, number]) {
+    const heading = geometry.computeHeading(centroid1, centroid2);
+    if (heading >= 337.5 || heading < 22.5) {
+        return 'north';
+    }
+    if (heading < 67.5) {
+        return 'north east';
+    }
+    if (heading < 112.5) {
+        return 'east';
+    }
+    if (heading < 157.5) {
+        return 'south east';
+    }
+    if (heading < 202.5) {
+        return 'south';
+    }
+    if (heading < 247.5) {
+        return 'south west';
+    }
+    if (heading < 292.5) {
+        return 'west';
+    }
+    if (heading < 337.5) {
+        return 'north west';
+    }
+    return 'not sure lol';
+}
+
+export function polygonDirection(country1: Country, country2: Country): string {
+    const points1 = polygonPoints(country1);
+    const points2 = polygonPoints(country2);
+    const centroid1 = polygonNaiveCentroid(points1);
+    const centroid2 = polygonNaiveCentroid(points2);
+    return calcDirection(centroid1, centroid2);
+}

--- a/src/util/distance.ts
+++ b/src/util/distance.ts
@@ -1,30 +1,6 @@
 import * as geometry from "spherical-geometry-js";
 import { Country } from "../lib/country";
-
-function pointToCoordinates(point: Array<number>) {
-  // In the data, coordinates are [E/W (lng), N/S (lat)]
-  // In the function, coordinates are [N/S (lat), E/W (lng)]
-  // For both, West and South are negative
-  const [lng, lat] = point;
-  const coord = new geometry.LatLng(lat, lng);
-  return coord;
-}
-
-function polygonPoints(country: Country) {
-  const { geometry } = country;
-  switch (geometry.type) {
-    case "Polygon":
-      return geometry.coordinates[0];
-    case "MultiPolygon":
-      let points: number[][] = [];
-      for (const polygon of geometry.coordinates) {
-        points = [...points, ...polygon[0]];
-      }
-      return points;
-    default:
-      throw new Error("Country data error");
-  }
-}
+import {polygonPoints, pointToCoordinates} from "./geometry"
 
 function calcProximity(points1: number[][], points2: number[][]) {
   // Find min distance between 2 sets of points

--- a/src/util/geometry.ts
+++ b/src/util/geometry.ts
@@ -1,0 +1,27 @@
+import * as geometry from "spherical-geometry-js";
+import {Country} from "../lib/country";
+
+export function pointToCoordinates(point: Array<number>) {
+    // In the data, coordinates are [E/W (lng), N/S (lat)]
+    // In the function, coordinates are [N/S (lat), E/W (lng)]
+    // For both, West and South are negative
+    const [lng, lat] = point;
+    const coord = new geometry.LatLng(lat, lng);
+    return coord;
+}
+
+export function polygonPoints(country: Country): number[][] {
+    const { geometry } = country;
+    switch (geometry.type) {
+        case "Polygon":
+            return geometry.coordinates[0];
+        case "MultiPolygon":
+            let points: number[][] = [];
+            for (const polygon of geometry.coordinates) {
+                points = [...points, ...polygon[0]];
+            }
+            return points;
+        default:
+            throw new Error("Country data error");
+    }
+}


### PR DESCRIPTION
This uses great circle bearing, which can be counter-intuitive as e.g. the direction from UK to Canada (or USA to China) is "north", where one would typically expect the "rhumb line" direction (east or west in these cases).

Having thought about it over the weekend, I think this might actually be the correct implementation for Globle. It is, after all, the path along which the distance for the distance hint is measured - if we were to use the rhumb line direction, it would be more correct to use the rhumb line distance as well.

In Globle, the user interacts with a globe. It's right there in the name. Using great circle direction is a chance for ordinary people to encounter first hand the kinds of real world problems that arise from spherical navigation, problems e.g. airline pilots engage with every day.

This counter-intuitiveness also adds an element of difficulty which acts against direction hinting making the game "too easy".

Arguably this implementation isn't actually complete - the directions themselves should also be localised.