### PR TITLE
Fix Georgia's name in Swedish

### DIFF
--- a/src/data/country_data.json
+++ b/src/data/country_data.json
@@ -10043,7 +10043,7 @@
         "NAME_PL": "Gruzja",
         "NAME_PT": "Abecásia",
         "NAME_RU": "Абхазия",
-        "NAME_SV": "Abchazien",
+        "NAME_SV": "Georgien",
         "NAME_TR": "Abhazya",
         "NAME_UK": "Абхазія",
         "NAME_UR": "ابخازيا",


### PR DESCRIPTION
In Swedish, Georgia is called "Georgien", not "Abchazien". Abchazien is a part of Georgia.